### PR TITLE
Update main.coffee

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs'
 path = require 'path'
-extend = require 'extend'
+# extend = require 'extend'
 {Disposable, CompositeDisposable} = require 'atom'
 
 ProcessManager = require './process_manager'


### PR DESCRIPTION
Cannot find module 'extend'
@ atom 1.0.7, Ubuntu15.04
