### PR TITLE
Added Option to enable/disable output opening + small fix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -29,5 +29,13 @@ export default {
     type: 'boolean',
     default: false,
     order: 6
+  },
+
+  openOutputEnabled: {
+    title: 'Open Output',
+    description: 'Open the output file after successful compilation.',
+    type: 'boolean',
+    default: true,
+    order: 7
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -153,10 +153,6 @@ export default {
 
   openOutput() {
     // copy and open the output upon successful compilation
-    if (!atom.config.get("latex-plus.openOutputEnabled")) {
-      return;
-    }
-
     target = path.join(this.project.projectPath, path.basename(this.project.item));
     source = this.project.item;
     fs.exists(target, (exist) => {
@@ -173,6 +169,9 @@ export default {
           });
 
           write.on("finish", (ex) => {
+            if (!atom.config.get("latex-plus.openOutputEnabled")) {
+              return;
+            }
             for (pane of atom.workspace.getPaneItems()) {
               if (path.basename(pane.filePath) === path.basename(target)) {
                 return;

--- a/lib/main.js
+++ b/lib/main.js
@@ -153,6 +153,10 @@ export default {
 
   openOutput() {
     // copy and open the output upon successful compilation
+    if (!atom.config.get("latex-plus.openOutputEnabled")) {
+      return;
+    }
+
     target = path.join(this.project.projectPath, path.basename(this.project.item));
     source = this.project.item;
     fs.exists(target, (exist) => {
@@ -170,7 +174,7 @@ export default {
 
           write.on("finish", (ex) => {
             for (pane of atom.workspace.getPaneItems()) {
-              if (pane.filePath === target) {
+              if (path.basename(pane.filePath) === path.basename(target)) {
                 return;
               }
             }


### PR DESCRIPTION
- Added option to enable/diable automatic output opening.
- Fixed opening the output file multiple times due to mismatch of pane.filePath and target. E.g. when the
  LaTeX project resides in a symbolically linked directory.
