### PR TITLE
per-project latexmk options

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -25,6 +25,7 @@ export default class Compiler {
   execute(cmd, options, project) {
     args = this.arguments(project);
     command = `${cmd} ${args.join(" ")}`;
+    console.log(command);
     proc = exec(command, options, (err, stdout, stderr) => {
       this.pid = proc.pid;
       this.err = err;
@@ -41,16 +42,20 @@ export default class Compiler {
   arguments(project) {
     args = [];
 
-    latexmk_defaults = "-interaction=nonstopmode -f -cd -file-line-error";
-    args.push(latexmk_defaults);
-    args.push(project.latexmkOptions);
-
-    if (atom.config.get("latex-plus.bibtexEnabled")) {
-      args.push("-bibtex");
-    }
-
-    if (atom.config.get("latex-plus.shellEscapeEnabled")) {
-      args.push("-shell-escape");
+    latexmk_common = "-interaction=nonstopmode -f -cd -file-line-error -synctex=1";
+    latexmk_defaults = "-bibtex -pdf -shell-escape";
+    args.push(latexmk_common);
+    if (atom.config.get("latex-plus.advancedEnabled")) {
+      // Filter out unwanted options.
+      latexmk_options = project.latexmkOptions;
+      unwanted = ["-cd-", "-f-", "-h", "-help", "--help", "-xelatex", "-lualatex"];
+      var nUnwanted = unwanted.length;
+      for (var opt = 0; opt < nUnwanted; opt++) {
+          latexmk_options = latexmk_options.replace(new RegExp(unwanted[opt], 'g'), '');
+      }
+      args.push(latexmk_options);
+    } else {
+      args.push(latexmk_defaults);
     }
 
     if (project.texProgram != "pdflatex") {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -41,7 +41,9 @@ export default class Compiler {
   arguments(project) {
     args = [];
 
-    args.push("-interaction=nonstopmode -f -cd -pdf -file-line-error");
+    latexmk_defaults = "-interaction=nonstopmode -f -cd -file-line-error";
+    args.push(latexmk_defaults);
+    args.push(project.latexmkOptions);
 
     if (atom.config.get("latex-plus.bibtexEnabled")) {
       args.push("-bibtex");

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,21 +14,14 @@ export default {
     description: "Location of your custom TeX packages directory.",
     type: 'string',
     default: '',
+    order: 2
+  },
+
+  advancedEnabled: {
+    title: 'Enable advanced LaTeXmk Options',
+    type: 'boolean',
+    default: false,
     order: 3
-  },
-
-  bibtexEnabled: {
-    title: 'Enable BibTeX',
-    type: 'boolean',
-    default: false,
-    order: 5
-  },
-
-  shellEscapeEnabled: {
-    title: 'Enable Shell Escape',
-    type: 'boolean',
-    default: false,
-    order: 6
   },
 
   openOutputEnabled: {
@@ -36,7 +29,7 @@ export default {
     description: 'Open the output file after successful compilation.',
     type: 'boolean',
     default: true,
-    order: 7
+    order: 4
   },
 
   ghostscriptBin: {
@@ -44,6 +37,6 @@ export default {
     description: 'Path to ps2pdf and dvipdf',
     type: 'string',
     default: '',
-    order: 8
+    order: 5
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,5 +37,13 @@ export default {
     type: 'boolean',
     default: true,
     order: 7
+  },
+
+  ps2pdfBin: {
+    title: 'ps2pdf Bin',
+    description: "Path to ps2pdf and dvipdf.",
+    type: 'string',
+    default: '',
+    order: 8
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,9 +39,9 @@ export default {
     order: 7
   },
 
-  ps2pdfBin: {
-    title: 'ps2pdf Bin',
-    description: "Path to ps2pdf and dvipdf.",
+  ghostscriptBin: {
+    title: 'Ghostscript conversion utilities',
+    description: 'Path to ps2pdf and dvipdf',
     type: 'string',
     default: '',
     order: 8

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -23,12 +23,12 @@ export default class Environment {
       default:
     }
 
-    this.ps2pdfBin = atom.config.get("latex-plus.ps2pdfBin");
+    this.ghostscriptBin = atom.config.get("latex-plus.ghostscriptBin");
 
     // #TODO: resolve texBin automatically
     this.options = process.env;
     this.options.timeout = 60000;
-    this.options.PATH = this.texBin + this.delim + this.ps2pdfBin + this.delim + this.PATH;
+    this.options.PATH = this.texBin + this.delim + this.ghostscriptBin + this.delim + this.PATH;
 
     this.texInputs = atom.config.get("latex-plus.texInputs");
     if (this.texInputs != "") {

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -23,10 +23,12 @@ export default class Environment {
       default:
     }
 
+    this.ps2pdfBin = atom.config.get("latex-plus.ps2pdfBin");
+
     // #TODO: resolve texBin automatically
     this.options = process.env;
     this.options.timeout = 60000;
-    this.options.PATH = this.texBin + this.delim + this.PATH;
+    this.options.PATH = this.texBin + this.delim + this.ps2pdfBin + this.delim + this.PATH;
 
     this.texInputs = atom.config.get("latex-plus.texInputs");
     if (this.texInputs != "") {

--- a/lib/project.js
+++ b/lib/project.js
@@ -100,7 +100,7 @@ export default class Project extends File {
   "title": "LaTeX-Plus Project",
   "root": "main.tex",
   "program": "pdflatex",
-  "latexmkOptions": "-pdf",
+  "latexmkOptions": "-bibtex -pdf -shell-escape",
   "output": ".latex"
 }`
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -86,6 +86,7 @@ export default class Project extends File {
       this.texTitle = project.title;
       this.texRoot = texRoot;
       this.texProgram = project.texProgram;
+      this.latexmkOptions = project.latexmkOptions;
       this.texOutput = texOutput;
       this.texLog = path.join(this.texOutput, path.basename(this.texRoot).split(".")[0] + ".log");
       this.item = path.join(this.texOutput, path.basename(this.texRoot).split(".")[0] + ".pdf");
@@ -99,6 +100,7 @@ export default class Project extends File {
   "title": "LaTeX-Plus Project",
   "root": "main.tex",
   "program": "pdflatex",
+  "latexmkOptions": "-pdf",
   "output": ".latex"
 }`
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,5 @@
       }
     }
   },
-  "activationCommands": {
-    "atom-workspace": "latex-plus:compile"
-  }
+  "activationHooks": ["language-latex:grammar-used"]
 }


### PR DESCRIPTION
Does this look reasonable? It appears to work as intended. The path to `ps2pdf` is necessary, at least on OSX, because it doesn't ship with TexLive. Users might install it with Homebrew, in which case it would appear in a location that isn't on the default `PATH`.

This PR is a first step only because `latexmkOptions` could conflict with `bibtexEnabled` and `shellEscapeEnabled`. I'd propose:
- [x] change `bibtexEnabled` to `bibtexDisabled` because `latexmk` runs BibTeX by default
- [x] check for conflict with `shellEscapeEnabled` or leave it entirely to `latexmkOptions`
- [x] `latexmkOptions` could also take care of passing `-xelatex` or `-lualatex` to `latexmk`
