### PR TITLE
clean with latexmk

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -10,6 +10,10 @@ export default class Compiler {
     this.emitter = new Emitter;
   }
 
+  onDidCleanSuccess(callback) {
+    this.emitter.on("did-clean-success", callback);
+  }
+
   onDidCompileSuccess(callback) {
     this.emitter.on("did-compile-success", callback);
   }
@@ -22,9 +26,10 @@ export default class Compiler {
     this.emitter.dispose();
   }
 
-  execute(cmd, options, project) {
-    args = this.arguments(project);
+  latex_build(cmd, options, project) {
+    args = this.build_args(project);
     command = `${cmd} ${args.join(" ")}`;
+    console.log(command)
     proc = exec(command, options, (err, stdout, stderr) => {
       this.pid = proc.pid;
       this.err = err;
@@ -38,7 +43,20 @@ export default class Compiler {
     });
   }
 
-  arguments(project) {
+  latex_clean(cmd, options, project) {
+    args = this.clean_args(project);
+    command = `${cmd} ${args.join(" ")}`;
+    console.log(command)
+    proc = exec(command, options, (err, stdout, stderr) => {
+      this.pid = proc.pid;
+      this.err = err;
+      this.stdout = stdout;
+      this.stderr = stderr;
+      this.emitter.emit("did-clean-success");
+    });
+  }
+
+  build_args(project) {
     args = [];
 
     args.push("-interaction=nonstopmode -f -cd -pdf -file-line-error");
@@ -59,6 +77,14 @@ export default class Compiler {
     args.push(`\"${project.texRoot}\"`);
 
     return args
+  }
+
+  clean_args(project) {
+    args = [];
+    args.push("-C -cd");
+    args.push(`-outdir=\"${project.texOutput}\"`);
+    args.push(`\"${project.texRoot}\"`);
+    return args;
   }
 
   kill(pid) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,7 +4,6 @@ import fs from "fs";
 import path from "path";
 
 import {Disposable, CompositeDisposable} from 'atom';
-import rimraf from "rimraf";
 
 import Config from "./config";
 import Project from "./project";
@@ -33,30 +32,15 @@ export default {
           return;
         }
 
-        this.status.updateStatusBarMode("compile");
-        this.compiler.execute("latexmk", this.environment.options, this.project);
+        this.status.updateStatusBarMode("compiling");
+        this.compiler.latex_build("latexmk", this.environment.options, this.project);
       },
       "latex-plus:edit": () => {
         this.project.edit()
       },
       "latex-plus:clean": () => {
-        if (this.project.error) {
-          return;
-        }
-
-        shouldClean = atom.confirm({
-          message: `Are you sure you want to clean ${this.project.texOutput}?`,
-          detailedMessage: "This cannot be recovered. Be absolutely certain that you are not cleaning files you would like to keep.",
-          buttons: ["Cancel", "Clean"]
-        });
-
-        if (shouldClean) {
-          rimraf(this.project.texOutput, (e) => {
-            if (e) {
-              throw(e);
-            }
-          });
-        }
+        this.status.updateStatusBarMode("cleaning");
+        this.compiler.latex_clean("latexmk", this.environment.options, this.project);
       }
     });
 
@@ -64,6 +48,14 @@ export default {
         this.environment = new Environment();
       })
     )
+
+    cleanSuccessEvent = new Disposable(
+      this.compiler.onDidCleanSuccess(() => {
+        this.status.updateStatusBarTitle(this.project.texTitle)
+        this.status.updateStatusBarMode("ready")
+        this.status.clear();
+      }
+    ));
 
     compileSuccessEvent = new Disposable(
       this.compiler.onDidCompileSuccess(() => {
@@ -93,7 +85,8 @@ export default {
     }));
 
     this.configSubscriptions = new CompositeDisposable(configChangedEvent);
-    this.compilerSubscriptions = new CompositeDisposable(compileSuccessEvent,
+    this.compilerSubscriptions = new CompositeDisposable(cleanSuccessEvent,
+                                                         compileSuccessEvent,
                                                          compileErrorEvent);
   },
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-message-panel": "latest",
-    "rimraf": "latest"
+    "atom-message-panel": "latest"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
This PR changes the cleanup mechanism to `latexmk -C`. This removes the dependency on `rimraf` and streamlines the code a bit. I removed the confirmation dialog since `latexmk` only deletes files that can be re-generated.

Let me know how this looks.
