### PR TITLE
symlink pdf and synctex files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -201,31 +201,20 @@ export default {
     }
   },
 
-  async copyOverFile(source, target) {
-    fs.exists(target, (exists) => {
-      if (exists) {
-        fs.unlink(target, () => {
-          read = fs.createReadStream(source);
-          read.on("error", (e) => {
-            throw e;
-          });
-
-          write = fs.createWriteStream(target);
-          write.on("error", (e) => {
-            throw e;
-          });
-          // write.on("finish", callback);
-
-          read.pipe(write);
-        });
-      }
-    });
-  },
-
   async openOutput() {
-    // copy and open the output upon successful compilation
-    await this.copyOverFile(this.project.texSyncTeX, path.join(this.project.projectPath, path.basename(this.project.texSyncTeX)));
-    await this.copyOverFile(this.project.item, path.join(this.project.projectPath, path.basename(this.project.item)));
+    // link and open the output upon successful compilation
+    await fs.symlink(
+            this.project.texSyncTeX,
+            path.join(this.project.projectPath, path.basename(this.project.texSyncTeX)),
+            function (err) {
+              console.log("cannot link " + path.basename(this.project.texSyncTeX) + " : " + err);
+            });
+    await fs.symlink(
+            this.project.item,
+            path.join(this.project.projectPath, path.basename(this.project.item)),
+            function (err) {
+              console.log("cannot link " + path.basename(this.project.item) + " : " + err);
+            });
 
     if (!atom.config.get("latex-plus.openOutputEnabled")) {
       return;


### PR DESCRIPTION
Create symbolic links instead of copying the PDF and synctex.gz files.
Fixes #36.
