### PR TITLE
Fix #40: Remove symlinks when they have another target

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -203,18 +203,59 @@ export default {
 
   async openOutput() {
     // link and open the output upon successful compilation
-    await fs.symlink(
-            this.project.texSyncTeX,
-            path.join(this.project.projectPath, path.basename(this.project.texSyncTeX)),
-            function (err) {
-              console.log("cannot link " + path.basename(this.project.texSyncTeX) + " : " + err);
+    let unlinkSymlink = function(target, path) {
+      return new Promise(function(resolve, reject) {
+        fs.readlink(path, function(err, linkString) {
+          if (err && err.code === "ENOENT") {
+            // No need to remove because there exists no entry at the path
+            resolve(true);
+          }
+          else if (err) {
+            reject(err);
+          }
+          else if (linkString === target) {
+            // No need to remove because symlink at path points to target
+            resolve(false);
+          }
+          else {
+            fs.unlink(path, function(err) {
+              if (err) {
+                reject(err);
+              }
+              resolve(true);
             });
-    await fs.symlink(
-            this.project.item,
-            path.join(this.project.projectPath, path.basename(this.project.item)),
-            function (err) {
-              console.log("cannot link " + path.basename(this.project.item) + " : " + err);
-            });
+          }
+        });
+      });
+    };
+    let symlink = function(target, path) {
+      return new Promise(function(resolve, reject) {
+        fs.symlink(target, path,
+          function (err) {
+            if (err) {
+              reject(err);
+            }
+            resolve();
+          }
+        );
+      });
+    };
+    let errorCallback = function(target, path, err) {
+      atom.notifications.addError(
+        "Error while symlinking " + path + " to " + target,
+        {detail: err.toString()}
+      );
+    };
+    let syncTexPath = path.join(this.project.projectPath, path.basename(this.project.texSyncTeX));
+    let syncTexTargetPath = this.project.texSyncTeX;
+    let itemPath = path.join(this.project.projectPath, path.basename(this.project.item));
+    let itemTargetPath = this.project.item;
+    await unlinkSymlink(syncTexTargetPath, syncTexPath)
+      .then(function(res) { if (res) { symlink(syncTexTargetPath, syncTexPath); }})
+      .catch(errorCallback.bind(this, syncTexTargetPath, syncTexPath));
+    await unlinkSymlink(itemTargetPath, itemPath)
+      .then(function(res) { if (res) { symlink(itemTargetPath, itemPath); }})
+      .catch(errorCallback.bind(this, itemTargetPath, itemPath));
 
     if (!atom.config.get("latex-plus.openOutputEnabled")) {
       return;


### PR DESCRIPTION
Old behavior: When objects at the symlinks' paths exist, do nothing and
log an error. Else create the symlinks.

New behavior: When symlinks at the paths exist and point to correct
targets, do nothing. If they point to another target, delete them and
create new ones. If there are files or directories at the paths, show an
error message to the user. If there is nothing, create the symlinks.

More information can be found at #40 
