### PR TITLE
Reactivate editor after opening output

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -261,20 +261,10 @@ export default {
       return;
     }
 
-    alreadyOpen = false;
-    for (pane of atom.workspace.getPaneItems()) {
-      if (path.basename(pane.filePath) === path.basename(this.project.item)) {
-        alreadyOpen = true;
-        break;
-      }
-    }
-
-    if (!alreadyOpen) {
-      pane = atom.workspace.getActivePane();
-      outputPane = pane.splitRight();
-      await atom.workspace.open(path.basename(this.project.item), outputPane);
-      this.viewer = atom.workspace.getActivePaneItem();
-    }
+    const previousActivePane = atom.workspace.getActivePane();
+    const options = { split: 'right', searchAllPanes: true };
+    this.viewer = await atom.workspace.open(path.basename(this.project.item), options);
+    previousActivePane.activate();
   },
 
   getRootPath() {


### PR DESCRIPTION
Previous behavior: Upon initial opening of the output, the output pane
was activated, resulting in losing input when the user continued typing
after starting the compilation process. When the output was already
opened, the editor would stay activated though, thus confusing the user
with 2 different behaviors for the same action.

New behavior: The editor is always activated after opening the output.
To interact with the output view (e.g. go to page) the user has to
manually activate it (e.g. by clicking into it).

This has been heavily influenced by the according code in the official [markdown-preview package](https://github.com/atom/markdown-preview/blob/73334c7e4191e5673196772fd835f989fb284642/lib/main.coffee#L84).

This also fixes some other bugs, in particular:
- When there already was a right pane, opening the output resulted in a third pane in the middle. Now, the output is just opened in the right pane.
- When a window with the output file open was reopened (e.g. due to closing atom and opening it again), syncing the view would not work (even after compiling) because `this.viewer` was not set when the output was already open. 
