### PR TITLE
Add command for compiling and syncing the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ Due to the beta status of this package, project configuration files will be over
 #### Keymaps
 
 ###### OS X
-* compile project: `cmd-;`
+* compile and sync project: `cmd-;`
+* compile project: `alt-cmd-:`
 * sync project: `alt-cmd-;`
 * edit project: `cmd-'`
 * clean project: `alt-cmd-'`
 
 ###### Linux and Windows
-* compile project: `ctrl-;`
+* compile and sync project: `ctrl-;`
+* compile project: `alt-ctrl-:`
 * sync project `ctrl-alt-;`
 * edit project: `ctrl-'`
 * clean project: `ctrl-alt-'`

--- a/keymaps/keymaps.cson
+++ b/keymaps/keymaps.cson
@@ -1,17 +1,20 @@
 ".platform-darwin atom-text-editor":
-  "cmd-;": "latex-plus:compile"
+  "cmd-;": "latex-plus:compile-and-sync"
+  "alt-cmd-:": "latex-plus:compile"
   "cmd-'": "latex-plus:edit"
   "alt-cmd-;": "latex-plus:sync"
   "alt-cmd-'": "latex-plus:clean"
 
 ".platform-linux atom-text-editor":
-  "ctrl-;": "latex-plus:compile"
+  "ctrl-;": "latex-plus:compile-and-sync"
+  "alt-ctrl-:": "latex-plus:compile"
   "ctrl-'": "latex-plus:edit"
   "ctrl-alt-;": "latex-plus:sync"
   "ctrl-alt-'": "latex-plus:clean"
 
 ".platform-win32 atom-text-editor":
-  "ctrl-;": "latex-plus:compile"
+  "ctrl-;": "latex-plus:compile-and-sync"
+  "alt-ctrl-:": "latex-plus:compile"
   "ctrl-'": "latex-plus:edit"
   "ctrl-alt-;": "latex-plus:sync"
   "ctrl-alt-'": "latex-plus:clean"

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -26,7 +26,7 @@ export default class Compiler {
     this.emitter.dispose();
   }
 
-  latex_build(cmd, options, project) {
+  latex_build(cmd, options, project, userData) {
     args = this.build_args(project);
     command = `${cmd} ${args.join(" ")}`;
     console.log(command);
@@ -36,10 +36,10 @@ export default class Compiler {
       this.stdout = stdout;
       this.stderr = stderr;
       if (err) {
-        this.emitter.emit("did-compile-error");
+        this.emitter.emit("did-compile-error", userData);
       }
       else {
-        this.emitter.emit("did-compile-success");
+        this.emitter.emit("did-compile-success", userData);
       }
     });
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,6 +37,30 @@ export default {
         this.status.updateStatusBarMode("compile");
         this.compiler.latex_build("latexmk", this.environment.options, this.project);
       },
+      "latex-plus:compile-and-sync": async () => {
+        this.saveAll();
+        try {
+          await this.setProject();
+        }
+        catch (e) {
+          console.log(e);
+          return;
+        }
+
+        const editor = atom.workspace.getActivePaneItem();
+        const syncOptions = {
+          filePath: editor.buffer.file.path,
+          cursorPosition: editor.getCursorBufferPosition()
+        };
+
+        this.status.updateStatusBarMode("compile");
+        this.compiler.latex_build(
+          "latexmk",
+          this.environment.options,
+          this.project,
+          syncOptions
+        );
+      },
       "latex-plus:sync": async () => {
         if (! this.project) {
           try {
@@ -52,7 +76,12 @@ export default {
         await this.openOutput();
 
         this.status.updateStatusBarMode("sync");
-        this.synctex.syncView(editor, this.viewer, this.environment.options);
+        this.synctex.syncView(
+          editor.buffer.file.path,
+          editor.getCursorBufferPosition(),
+          this.viewer,
+          this.environment.options
+        );
       },
       "latex-plus:edit": async () => {
         if (! this.project) {
@@ -109,11 +138,23 @@ export default {
     ));
 
     compileSuccessEvent = new Disposable(
-      this.compiler.onDidCompileSuccess(() => {
+      this.compiler.onDidCompileSuccess(async (syncOptions) => {
         this.status.updateStatusBarTitle(this.project.texTitle);
-        this.status.updateStatusBarMode("ready");
-        this.status.clear();
-        this.openOutput();
+        if (syncOptions !== undefined) {
+          this.status.updateStatusBarMode("sync");
+          await this.openOutput();
+          this.synctex.syncView(
+            syncOptions.filePath,
+            syncOptions.cursorPosition,
+            this.viewer,
+            this.environment.options
+          );
+        }
+        else {
+          this.status.updateStatusBarMode("ready");
+          this.status.clear();
+          this.openOutput();
+        }
       }
     ));
 

--- a/lib/synctex.js
+++ b/lib/synctex.js
@@ -39,10 +39,10 @@ export default class SyncTeX {
     });
   }
 
-  syncView(editor, viewer, environment) {
+  syncView(sourceFile, cursorPosition, viewer, environment) {
     this.execute(
-      editor.buffer.file.path,
-      editor.getCursorBufferPosition(),
+      sourceFile,
+      cursorPosition,
       viewer.file.path,
       environment,
       (syncData) => {


### PR DESCRIPTION
Closes #42.

The shortcut `cmd-;` / `ctrl-;` has been remapped to this new command as
it is more likely to be the expected behavior.
Users who want to keep the old behavior can easily remap the commands.

If you don't agree about the remapping, just tell me and I can undo it.
