### PR TITLE
Update main.js

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -309,7 +309,7 @@ export default {
 
     const previousActivePane = atom.workspace.getActivePane();
     const options = { split: 'right', searchAllPanes: true };
-    this.viewer = await atom.workspace.open(path.basename(this.project.item), options);
+    this.viewer = await atom.workspace.open(itemPath, options);
     previousActivePane.activate();
   },
 


### PR DESCRIPTION
This closes my issue #51
this.project.item resolved to "x.pdf" when your tex is called "x.tex". 
Somehow pdf-viewer under linux seems to need the whole path of the symlink to open the pdf!
Shortening itemPath is just an unneccesary step!
