### PR TITLE
per project open output

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,14 +32,6 @@ export default {
     order: 4,
   },
 
-  openOutputEnabled: {
-    title: "Open Output",
-    description: "Open the output file after successful compilation.",
-    type: "boolean",
-    default: true,
-    order: 5,
-  },
-
   synctexVertAlign: {
     title: "SyncTeX Vertical Alignment",
     description: "A number between 0 (top) and 1 (bottom), e.g., 0.5 for vertical centering.",
@@ -47,6 +39,6 @@ export default {
     default: 0.0,
     minimum: 0.0,
     maximum: 1.0,
-    order: 6,
+    order: 5,
   },
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -303,7 +303,7 @@ export default {
       .then(function(res) { if (res) { symlink(itemTargetPath, itemPath); }})
       .catch(errorCallback.bind(this, itemTargetPath, itemPath));
 
-    if (!atom.config.get("latex-plus.openOutputEnabled")) {
+    if (!this.project.openOutput) {
       return;
     }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -94,6 +94,7 @@ export default class Project extends File {
       this.texLog = path.join(this.texOutput, path.basename(this.texRoot).split(".")[0] + ".log");
       this.item = path.join(this.texOutput, path.basename(this.texRoot).split(".")[0] + ".pdf");
       this.texSyncTeX = path.join(this.texOutput, path.basename(this.texRoot).split(".")[0] + ".synctex.gz");
+      this.openOutput = project.openOutput == "true";
     });
   }
 
@@ -105,7 +106,8 @@ export default class Project extends File {
   "root": "${this.relativePath}",
   "program": "pdflatex",
   "latexmkOptions": "-bibtex -pdf -shell-escape",
-  "output": ".latex"
+  "output": ".latex",
+  "openOutput": "true"
 }`;
 
     try {


### PR DESCRIPTION
Move the option to open the PDF to the per-project config file. PDF.js isn't well suited to opening Beamer presentations. `openOutput` is activated by default.
