### PR TITLE
Better handling of TEXINPUTS

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ export default {
 
   texInputs: {
     title: "TeX Packages",
-    description: "Location of your custom TeX packages directory.",
+    description: "Nonstandard paths to search for TeX packages. Standard locations are `~/texmf` on Linux and `~/Library/texmf` on OSX/MacOS. Separate paths with a colon (:). End paths to search recursively with a double slash (//). Prepend a dot (.) to search the local folder first. A trailing colon will be added automatically to search system paths.",
     type: "string",
     default: "",
     order: 3,

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -31,10 +31,16 @@ export default class Environment {
     this.options.PATH = this.texBin + this.delim + this.ghostscriptBin + this.delim + this.PATH;
 
     this.texInputs = atom.config.get("latex-plus.texInputs");
-    if (this.texInputs !== "") {
-      // TEXINPUTS seems to only be available on *nix operating systems
-      if (process.platform !== "win32") {
-        this.options.TEXINPUTS = this.texInputs + this.delim;
+    // TEXINPUTS seems to only be available on *nix operating systems
+    if (process.platform !== "win32") {
+      if (this.texInputs !== "") {
+        if (this.texInputs.endsWith(this.delim)) {
+          this.options.TEXINPUTS = this.texInputs;
+        } else {
+          this.options.TEXINPUTS = this.texInputs + this.delim; // append system search path
+        }
+      } else {
+        this.options.TEXINPUTS = ""; // so it is not "undefined"
       }
     }
 


### PR DESCRIPTION
If the `TeX Packages` option is left blank, `TEXINPUTS` ends up being `"undefined"` in the environment, causing issues finding TeX packages.

This PR also documents the `TeX Packages` options more thoroughly since setting it is not quite like setting other paths.