### PR TITLE
Avoid error when syncing projects for which the output isn't opened

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -153,7 +153,7 @@ export default {
     compileSuccessEvent = new Disposable(
       this.compiler.onDidCompileSuccess(async (syncOptions) => {
         this.status.updateStatusBarTitle(this.project.texTitle);
-        if (syncOptions !== undefined) {
+        if (syncOptions !== undefined && this.project.openOutput) {
           this.status.updateStatusBarMode("sync");
           await this.openOutput();
           this.synctex.syncView(


### PR DESCRIPTION
If `this.project.openOutput` is `false`, `this.viewer` is undefined a line 162, causing an error when retrieving `viewer.file.path` [here](https://github.com/andrewrynhard/atom-latex-plus/blob/master/lib/synctex.js#L49).